### PR TITLE
CF paradrop R21

### DIFF
--- a/mcc/fnc/cas/fn_createPlane.sqf
+++ b/mcc/fnc/cas/fn_createPlane.sqf
@@ -43,15 +43,14 @@ if (_vehicleClass == "autonomous") then {
 
 //Give it more hight and velocity if we are spawning a jet
 if !(_plane isKindOf "Helicopter") then {
-	_plane setpos [(getPos _plane select 0),(getPos _plane select 1),(getPos _plane select 2)+100];
+	// _plane setpos [(getPos _plane select 0),(getPos _plane select 1),(getPos _plane select 2)+100];
 	private ["_vel","_dir","_speed"];
 	_vel = velocity _plane;
 	_dir = direction _plane;
-	_speed = 10;
-	_plane setVelocity [(_vel select 0)+(sin _dir*_speed),(_vel select 1)+(cos _dir*_speed),(_vel select 2)];
-
-	// set marker on map
-	//[_plane, "B_AIR", _planeType, "ColorBlack", 99] execVM MCC_path + "mcc\general_scripts\cas\cas_marker.sqf";
+	_speed = 100;
+	_plane setVelocity [(sin _dir*_speed),(cos _dir*_speed),0];
+	// _plane setVelocity [(_vel select 0)+(sin _dir*_speed),(_vel select 1)+(cos _dir*_speed),(_vel select 2)];
+	// _plane setVelocity [0,0,65];
 };
 
 _plane

--- a/mcc/fnc/cas/fn_deletePlane.sqf
+++ b/mcc/fnc/cas/fn_deletePlane.sqf
@@ -23,7 +23,7 @@ _pilotGroup setSpeedMode "FULL";
 _pilotGroup setCombatMode "BLUE";
 _pilotGroup setBehaviour "CARELESS";
 _plane disableAI "AUTOTARGET";
-if (IsNil "_flyInHeight") then { _flyInHeight = 300; };
+// if (IsNil "_flyInHeight") then { _flyInHeight = 300; };
 _plane flyInHeight _flyInHeight;
 
 if (isnil "_away") then {_away = [100,100,100]};
@@ -33,8 +33,15 @@ _pilotGroup move _away;
 _pilot domove _away;
 
 // If plane is far away enough delete it
-waituntil {sleep 1;((_plane distance _away) < 800) || (!alive _plane);};
+// waituntil {sleep 1;((_plane distance _away) < 800) || (!alive _plane);};
+
+sleep 20;
+
+_crew = crew _plane;
+_group = group _plane;
 
 if (alive _plane) then {
-	{deleteVehicle _x} forEach crew _plane + [_plane];
+	deletevehicle _plane;
+	{deletevehicle _x} foreach _crew;
+	deletegroup _group;
 };

--- a/mcc/fnc/general/fn_paradrop.sqf
+++ b/mcc/fnc/general/fn_paradrop.sqf
@@ -118,6 +118,7 @@ if (_halo) then {
 					{
 						detach _x;
 						sleep 0.1;
+						clearBackpackCargo _x;
 						deleteVehicle _x;
 					};
 				} forEach attachedObjects _unit;
@@ -137,23 +138,24 @@ if (_halo) then {
 						};
 				} foreach _backPackItems;
 			};
+			
 
 			sleep 0.05;
 
 			// Add parachute backpack, this will place backpack on the ground near player
-			_unit addBackpack "B_Parachute";
+			// _unit addBackpack "B_Parachute";
 
-			hintSilent "pickup backpack or drop parachute to change gear";
+			// hintSilent "pickup backpack or drop parachute to change gear";
 
-			//Only if player grabs backpack the change gear scenario will be started
-			_timeOut = time + 600;
-			while { (alive _unit) && (backpack _unit == "B_Parachute") && (time < _timeOut) } do { sleep 0.5;};
+			// Only if player grabs backpack the change gear scenario will be started
+			// _timeOut = time + 600;
+			// while { (alive _unit) && (backpack _unit == "B_Parachute") && (time < _timeOut) } do { sleep 0.5;};
 
 			// if killed or after 10 minutes still no gear change exit HALO script
-			if ( !(alive _unit) || ( time > _timeOut )) exitwith {};
+			// if ( !(alive _unit) || ( time > _timeOut )) exitwith {};
 
 			//Remove HALO gear and add normal gear
-			cutText ["Changing Gear","BLACK OUT",0.5];
+			cutText ["Changing gear","BLACK OUT",0.5];
 
 			if (_headgear != "") then { removeHeadgear _unit; _unit addHeadgear _headgear };
 			if (_uniform != "") then { removeUniform _unit; _unit forceAddUniform  _uniform };
@@ -166,7 +168,7 @@ if (_halo) then {
 					case (isClass (configFile >> "CfgGlasses" >> _x)) : {player additem _x};
 				};
 			} foreach _uniformItems;
-			sleep 4;
+			sleep 1;
 			cutText ["","BLACK IN",2];
 		}
 		else
@@ -185,6 +187,7 @@ if (_halo) then {
 
 			_unit setCombatMode "AWARE";
 		};
+		
 } else {
 
 	//Parachute

--- a/mcc/fnc/general/fn_realParadrop.sqf
+++ b/mcc/fnc/general/fn_realParadrop.sqf
@@ -25,7 +25,7 @@ _chockArray = [];
 if (_UMUnit==0) then {
 	{
 		_unitsArray pushBack _x;
-		if (count _unitsArray >= 12) then {
+		if (count _unitsArray >= 18) then {
 			_chockArray pushBack _unitsArray;
 			_unitsArray	= [];
 		};
@@ -34,7 +34,7 @@ if (_UMUnit==0) then {
 	{
 		{
 			_unitsArray pushBack _x;
-			if (count _unitsArray >= 12) then {
+			if (count _unitsArray >= 18) then {
 				_chockArray  pushBack _unitsArray;
 				_unitsArray	= [];
 			};
@@ -45,11 +45,11 @@ if (_UMUnit==0) then {
 _heliClass = if (_isHalo == 1) then  {"O_Heli_Transport_04_F"} else {
 				switch (true) do
 				{
-					case (side (_units select 0) == east && (isClass(configFile >> "CfgVehicles" >> "O_T_VTOL_02_infantry_F"))):{"O_T_VTOL_02_infantry_F"};
+					case (side (_units select 0) == east && (isClass(configFile >> "CfgVehicles" >> "RHS_C130J"))):{"RHS_C130J"};
 
-					case (side (_units select 0) == west && (isClass(configFile >> "CfgVehicles" >> "B_T_VTOL_01_infantry_F"))):{"B_T_VTOL_01_infantry_F"};
+					case (side (_units select 0) == west && (isClass(configFile >> "CfgVehicles" >> "RHS_C130J"))):{"RHS_C130J"};
 
-					default{"I_Heli_Transport_02_F"};
+					default{"RHS_C130J"};
 				};
 			};
 

--- a/mcc/fnc/general/fn_realParadropPlayer.sqf
+++ b/mcc/fnc/general/fn_realParadropPlayer.sqf
@@ -108,6 +108,8 @@ while {!_jumpReady} do {
 	_jumpReady = _plane getvariable "MCCjumpReady";
 };
 
+_unit allowdamage false;
+
 /*
 //Make them stand on the ramp
 if (isplayer _unit) then {

--- a/mcc/general_scripts/groupGen/mouseDown.sqf
+++ b/mcc/general_scripts/groupGen/mouseDown.sqf
@@ -365,8 +365,8 @@ if (mcc_missionmaker == (name player)) then {
 		// set plane spawn and away position
 		_markerPos 	= getmarkerpos _marker;
 		_markerDir 	= markerDir _marker;
-		_spawn 		= [_markerPos,4500,(_markerDir -180)] call BIS_fnc_relpos;
-		_away 		= [_markerPos,4500,_markerDir] call BIS_fnc_relpos;
+		_spawn 		= [_markerPos,4000,(_markerDir -180)] call BIS_fnc_relpos;
+		_away 		= [_markerPos,4000,_markerDir] call BIS_fnc_relpos;
 
 		//[getmarkerpos _marker, MCC_selectedUnits, MCC_UMUnit, MCC_UMparadropIsHalo,_spawn,_away] execVM "mcc\fnc\general\fn_realParadrop.sqf";
 


### PR DESCRIPTION
Based on CF branch R21
- Replaced halo planes with C130s for all factions.
- Fixed a bug where initial  speed wasn't properly set for halo planes.
- Increased spawn distance from drop zones for halo planes.
- Fixed a bug where halo planes weren't getting deleted after the drop
- Removed the need to pick up your backpack after halo dropping. Your gear will now automatically be restored upon touching the ground.
- Hopefully fixed a bug where players would sometimes die immediately after getting dropped out of a plane during a halo drop